### PR TITLE
UDPN-2882: Fix()/Duplicated privilege attribute

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -30,7 +30,6 @@ services:
     image: redis:6.2.5
     container_name: redis
     restart: always
-    privileged: true
     environment:
       TZ: Asia/Shanghai
       LANG: en_US.UTF-8


### PR DESCRIPTION
## Descriptions

This PR fixes the bug of `privilege=true` Redis attribute duplicated caused by https://github.com/UDPN/BN-Sandbox-selfservice-public/commit/3d70375d0991f8e8958dae86f9322836883f1747#diff-a7a4797b6c35ac18778f39bbc46dd288747309e18ec6fb5dd4774adb524f80e2R33